### PR TITLE
Update readme to use correct package

### DIFF
--- a/packages/es-exec/README.md
+++ b/packages/es-exec/README.md
@@ -9,13 +9,13 @@ An api that builds and runs a program.
 npm
 
 ```sh
-npm install @es-exec/api
+npm install --save-dev @es-exec/api
 ```
 
 yarn
 
 ```sh
-yarn add @es-exec/api
+yarn add --dev @es-exec/api
 ```
 
 # Usage

--- a/plugins/es-serve/README.md
+++ b/plugins/es-serve/README.md
@@ -7,13 +7,13 @@ An esbuild plugin for running a module after it is build with esbuild. This proj
 npm
 
 ```sh
-npm install @es-exec/esbuild-plugin-es-serve
+npm install --save-dev @es-exec/esbuild-plugin-serve
 ```
 
 yarn
 
 ```sh
-yarn add @es-exec/esbuild-plugin-es-serve
+yarn add --dev @es-exec/esbuild-plugin-serve
 ```
 
 # Usage

--- a/plugins/es-start/README.md
+++ b/plugins/es-start/README.md
@@ -7,13 +7,13 @@ A plugin for running a script on esbuild end (kind of like nodemon).
 npm
 
 ```sh
-npm install @es-exec/esbuild-plugin-es-start
+npm install --save-dev @es-exec/esbuild-plugin-start
 ```
 
 yarn
 
 ```sh
-yarn add @es-exec/esbuild-plugin-es-start
+yarn add --dev @es-exec/esbuild-plugin-start
 ```
 
 # Usage


### PR DESCRIPTION
I tried installing your plugin using the install script provided in the readme and I realized you had deployed the scripts to npm under different names. This PR updates the readme files to match those script names.